### PR TITLE
Manager and command dispatcher error-handling refactor

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -67,11 +67,7 @@ func NewServer(cfg Config) (*Server, error) {
 		SocketConnectionTimeout: cfg.SocketConnectionTimeout,
 		StartMpvInstance:        cfg.StartMpvInstance,
 	}
-	mpvManager, err := mpv.NewManager(managerCfg)
-	if err != nil {
-		return nil, err
-	}
-
+	mpvManager := mpv.NewManager(managerCfg)
 	movies := state.NewMovies()
 	playback := state.NewPlayback()
 	playlists := state.NewPlaylists()
@@ -122,8 +118,17 @@ func NewServer(cfg Config) (*Server, error) {
 	return server, nil
 }
 
-// Serve starts handling requests to the API endpoints. Blocks until closed.
+// Serve starts handling API endpoints - both REST and SSE.
+// It also starts mpv manager.
+// Blocks until closed.
 func (s *Server) Serve() error {
+	go func() {
+		err := s.mpvManager.Serve()
+		if err != nil {
+
+		}
+	}()
+
 	serv := http.Server{
 		Addr:    s.address,
 		Handler: s.mainHandler(),

--- a/pkg/mpv/input_commands.go
+++ b/pkg/mpv/input_commands.go
@@ -1,10 +1,9 @@
 package mpv
 
 const (
+	getVersion             = "get_version"
 	loadfileCommand        = "loadfile"
-	setPropertyCommand     = "set_property"
 	observePropertyCommand = "observe_property_string"
-	stopCommand            = "stop"
 	playlistNextCommand    = "playlist-next"
 	playlistPrevCommand    = "playlist-prev"
 	playlistPlayIdxCommand = "playlist-play-index"
@@ -12,4 +11,6 @@ const (
 	playlistRemoveCommand  = "playlist-remove"
 	playlistMoveCommand    = "playlist-move"
 	playlistShuffleCommand = "playlist-shuffle"
+	setPropertyCommand     = "set_property"
+	stopCommand            = "stop"
 )

--- a/pkg/mpv/responses_iterator.go
+++ b/pkg/mpv/responses_iterator.go
@@ -7,6 +7,10 @@ import (
 	"net"
 )
 
+const (
+	bufSize = 512
+)
+
 type responsesIterator struct {
 	conn        net.Conn
 	accumulator []byte


### PR DESCRIPTION
Rewritten manager and command dispatcher to have only one function "Serve"
responsible for synchronizing relation between mpv process management and
command dispatcher serving and error-handling.
As a result, command dispatcher no longer maintains own goroutine
responsible for handling unix socket connection and serves synchronously,
leaving up to client (manager) to put it in a separate goroutine.