### PR TITLE
API & Manager server refactors

### DIFF
--- a/cmd/mpv-web-api/main.go
+++ b/cmd/mpv-web-api/main.go
@@ -66,11 +66,10 @@ func main() {
 	}
 	server, err := api.NewServer(cfg)
 	if err != nil {
-		errLog.Printf("could not start API server due to error: %s\n", err)
+		errLog.Printf("could not start API server due to an error: %s\n", err)
 
 		return
 	}
-	defer server.Close()
 
 	var moviesDirectories []string
 	if len(dir.Values()) == 0 {
@@ -84,7 +83,7 @@ func main() {
 		}
 	}
 
-	outLog.Printf("directories being watched for movie files:\n%s\n", strings.Join(moviesDirectories, ", "))
+	outLog.Printf("directories being watched for movie files: %s\n", strings.Join(moviesDirectories, ", "))
 	server.AddDirectories(moviesDirectories)
 
 	err = server.Serve()

--- a/pkg/api/property_events.go
+++ b/pkg/api/property_events.go
@@ -152,6 +152,8 @@ func (s *Server) handlePlaybackTimeEvent(res mpv.ObservePropertyResponse) error 
 	}
 
 	if currentTime == "" {
+		s.playback.SetPlaybackTime(0)
+
 		return nil
 	}
 

--- a/pkg/mpv/manager.go
+++ b/pkg/mpv/manager.go
@@ -325,7 +325,7 @@ func (m *Manager) serveCommandDispatcher() error {
 		m.outLog.Println("connecting command dispatcher...")
 
 		err = m.cd.Connect()
-		if errors.As(err, &ErrCheckConnectionFailure) {
+		if errors.Is(err, ErrCheckConnectionFailure) {
 			continue
 		} else if err != nil {
 			return err


### PR DESCRIPTION
Rewritten API & mpv Manager servers to make them blocking/synchronous.
Fixed bugs in ResponseIterator - mpv sends partial endline separated payloads
and iterator threw errors due to partial JSON's not being valid.
Fixed bug with Manager not stopping CommandDispatcher when error different
than connection check occured.
Some other small changes.