### PR TITLE
Fix payload not being propagated ocassionaly

### DIFF
--- a/pkg/mpv/responses_iterator.go
+++ b/pkg/mpv/responses_iterator.go
@@ -69,7 +69,7 @@ func (ri *responsesIterator) getNonEmptyChunkFromAccumulator() ([]byte, error) {
 	var firstNewByteIdx int = 0
 
 	for {
-		newlineIdx := bytes.Index(ri.accumulator[firstNewByteIdx:], newline)
+		newlineIdx := bytes.Index(ri.accumulator[firstNewByteIdx:], newline) + firstNewByteIdx
 		if newlineIdx != -1 {
 			chunk := ri.takeFromAccumulator(newlineIdx)
 			if len(chunk) == 0 {


### PR DESCRIPTION
Fixed payload not being propagated due to inifinite reading for
valid json from socket - while read was incompolete and only n last bytes
had to be checked for a newline, the index found during this search did
not take into account shift of n-new read bytes in accumulator.
This led to response itereator returning invalid json payloads, cut
at wrong index.