### PR TITLE
Implement watching of filesystem for new/removed media files

### DIFF
--- a/cmd/mpv-web-api/main.go
+++ b/cmd/mpv-web-api/main.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/sarpt/goutils/pkg/listflag"
 
+	"github.com/sarpt/mpv-web-api/internal/common"
 	"github.com/sarpt/mpv-web-api/pkg/api"
 )
 
@@ -28,12 +28,14 @@ const (
 	mpvSocketPathFlag    = "mpv-socket-path"
 	socketTimeoutSecFlag = "socket-timeout"
 	startMpvInstanceFlag = "start-mpv-instance"
+	watchDirFlag         = "watch-dir"
 )
 
 var (
 	address          *string
 	allowCORS        *bool
 	dir              *listflag.StringList
+	watchDir         *listflag.StringList
 	mpvSocketPath    *string
 	socketTimeoutSec *int64
 	startMpvInstance *bool
@@ -41,13 +43,15 @@ var (
 
 func init() {
 	dir = listflag.NewStringList([]string{})
+	watchDir = listflag.NewStringList([]string{})
 
-	flag.Var(dir, dirFlag, "directory containing media files. when left empty, current working directory will be used")
+	flag.Var(dir, dirFlag, "directory containing media files - the directory is not watched for changes")
 	address = flag.String(addressFlag, defaultAddress, "address on which server should listen on")
 	allowCORS = flag.Bool(allowCorsFlag, false, "when not provided, Cross Origin Site Requests will be rejected")
 	mpvSocketPath = flag.String(mpvSocketPathFlag, defaultMpvSocketPath, "path to a socket file used by a MPV instance to listen for commands")
 	socketTimeoutSec = flag.Int64(socketTimeoutSecFlag, defaultSocketTimeoutSec, "maximum allowed time in seconds for retrying connection to MPV instance")
 	startMpvInstance = flag.Bool(startMpvInstanceFlag, true, "controls whether the application should create and manage its own MPV instance")
+	flag.Var(watchDir, watchDirFlag, "directory containing media files - the directory will be watched for changes. When left empty and no --dir arguments are specified, current working directory will be used")
 
 	flag.Parse()
 }
@@ -71,19 +75,35 @@ func main() {
 		return
 	}
 
-	var mediaFilesDirectories []string
-	if len(dir.Values()) == 0 {
+	var mediaFilesDirectories []common.Directory
+	if len(dir.Values()) == 0 && len(watchDir.Values()) == 0 {
 		wd, err := os.Getwd()
-		if err == nil {
-			mediaFilesDirectories = append(mediaFilesDirectories, fmt.Sprintf("%s/", wd))
+		if err != nil {
+			errLog.Printf("could not start API server due to error while getting working directory: %s\n", err)
+
+			return
 		}
+
+		outLog.Printf("No directories specified for server - watching working directory '%s'\n", wd)
+		mediaFilesDirectories = append(mediaFilesDirectories, common.Directory{
+			Path:    fmt.Sprintf("%s/", wd),
+			Watched: true,
+		})
 	} else {
+		for _, dir := range watchDir.Values() {
+			mediaFilesDirectories = append(mediaFilesDirectories, common.Directory{
+				Path:    fmt.Sprintf("%s/", dir),
+				Watched: true,
+			})
+		}
+
 		for _, dir := range dir.Values() {
-			mediaFilesDirectories = append(mediaFilesDirectories, fmt.Sprintf("%s/", dir))
+			mediaFilesDirectories = append(mediaFilesDirectories, common.Directory{
+				Path: fmt.Sprintf("%s/", dir),
+			})
 		}
 	}
 
-	outLog.Printf("directories being watched for media files: %s\n", strings.Join(mediaFilesDirectories, ", "))
 	server.AddDirectories(mediaFilesDirectories)
 
 	err = server.Serve()

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sarpt/mpv-web-api
 go 1.14
 
 require (
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.2.0
 	github.com/sarpt/goutils v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
@@ -18,6 +20,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/common/directory.go
+++ b/internal/common/directory.go
@@ -1,0 +1,6 @@
+package common
+
+type Directory struct {
+	Path    string
+	Watched bool
+}

--- a/internal/rest/directories.go
+++ b/internal/rest/directories.go
@@ -6,7 +6,9 @@ import (
 	"github.com/sarpt/mpv-web-api/internal/common"
 )
 
-func (s *Server) SetAddDirectoriesHandler(handler func([]string) error) {
+type AddDirectoriesHandler = func([]common.Directory) error
+
+func (s *Server) SetAddDirectoriesHandler(handler AddDirectoriesHandler) {
 	s.addDirectoriesHandler = handler
 }
 
@@ -22,7 +24,11 @@ func (s *Server) directoriesPathHandler(res http.ResponseWriter, req *http.Reque
 	dirPath := req.PostFormValue(pathArg)
 	s.outLog.Printf("adding directory %s due to request from %s\n", dirPath, req.RemoteAddr)
 
-	return s.addDirectoriesHandler([]string{dirPath})
+	return s.addDirectoriesHandler([]common.Directory{
+		{
+			Path: dirPath,
+		},
+	})
 }
 
 func (s *Server) putDirectoriesFormArgumentsHandlers() map[string]common.FormArgument {

--- a/internal/rest/server.go
+++ b/internal/rest/server.go
@@ -30,7 +30,7 @@ type Config struct {
 // TODO#2: As in SSE case, the pointers to the state should be replaced with a more separated approach
 // - rest package should not have unlimited access to the whole state.
 type Server struct {
-	addDirectoriesHandler func([]string) error
+	addDirectoriesHandler AddDirectoriesHandler
 	allowCORS             bool
 	errLog                *log.Logger
 	mediaFiles            *state.MediaFiles

--- a/pkg/api/directories.go
+++ b/pkg/api/directories.go
@@ -3,21 +3,40 @@ package api
 import (
 	"fmt"
 	"os"
+
+	"github.com/sarpt/mpv-web-api/internal/common"
 )
 
-// AddDirectories executes probing of each directory concurrently.
-func (s *Server) AddDirectories(directories []string) error {
-	for _, directory := range directories {
-		info, err := os.Stat(directory)
-		if err != nil {
-			return err // TODO: directories added before will still be added, so it needs to be refactored for directories to be checked before probing (or aggregate probing errors)
-		}
+// ReadDirectory executes probing of directory concurrently.
+func (s *Server) ReadDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
 
-		if !info.IsDir() {
-			return fmt.Errorf("%w: %s", ErrPathNotDirectory, directory)
-		}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s", ErrPathNotDirectory, path)
+	}
 
-		go s.probeDirectory(directory)
+	go s.probeDirectory(path)
+
+	return nil
+}
+
+// AddDirectories adds root directories with media files to be handled by the server.
+// If the Directory entries are already present, they are overwritten along with their properties
+// (watched, recursive, etc.).
+// TODO: add posibility to disable recursivity
+func (s *Server) AddDirectories(directories []common.Directory) error {
+	for _, dir := range directories {
+		if dir.Watched {
+			err := s.fsWatcher.Add(dir.Path)
+			if err != nil {
+				s.errLog.Println(err)
+			}
+
+			s.ReadDirectory(dir.Path)
+		}
 	}
 
 	return nil

--- a/pkg/api/fs_watch.go
+++ b/pkg/api/fs_watch.go
@@ -1,0 +1,54 @@
+package api
+
+import "github.com/fsnotify/fsnotify"
+
+func (s *Server) handleFsEvent(event fsnotify.Event) error {
+	if shouldRemoveMediaPath(event.Op) {
+		s.outLog.Printf("removing media file '%s'\n", event.Name)
+		_, err := s.mediaFiles.Pop(event.Name)
+
+		return err
+	}
+
+	if shouldProbeMediaPath(event.Op) {
+		go s.probeFile(event.Name) // TODO: this does not necesarilly be run as a goroutine, change in the next commit with rest of probing refactor
+
+		return nil
+	}
+
+	return nil
+}
+
+func (s *Server) watchForFsChanges() {
+	go func() {
+		defer s.fsWatcher.Close()
+
+		for {
+			select {
+			case event, ok := <-s.fsWatcher.Events:
+				if !ok {
+					return
+				}
+
+				err := s.handleFsEvent(event)
+				if err != nil {
+					s.errLog.Printf("could not handle event '%s' due to an error: %s\n", event, err)
+				}
+			case err, ok := <-s.fsWatcher.Errors:
+				if !ok {
+					return
+				}
+
+				s.outLog.Printf("fs watcher returned an error: %s\n", err)
+			}
+		}
+	}()
+}
+
+func shouldProbeMediaPath(op fsnotify.Op) bool {
+	return op&fsnotify.Create == fsnotify.Create
+}
+
+func shouldRemoveMediaPath(op fsnotify.Op) bool {
+	return op&(fsnotify.Rename|fsnotify.Remove) != 0
+}

--- a/pkg/api/probe.go
+++ b/pkg/api/probe.go
@@ -16,7 +16,8 @@ func (s *Server) probeDirectory(directory string) {
 	s.outLog.Printf("probing directory %s\n", directory)
 
 	results := make(chan probe.Result)
-
+	// TODO: probe.Directory probably should be changed to probe.Directories(paths) or removed altogether,
+	// with probeDirectory from server taking walking the tree responsibilities
 	go probe.Directory(directory, results)
 	for probeResult := range results {
 		if !probeResult.IsMediaFile() {
@@ -28,4 +29,23 @@ func (s *Server) probeDirectory(directory string) {
 	}
 
 	s.outLog.Printf("finished probing directory %s\n", directory)
+}
+
+func (s *Server) probeFile(path string) {
+	s.outLog.Printf("probing file %s\n", path)
+
+	probeResult, err := probe.File(path)
+	if err != nil {
+		s.errLog.Printf("error while probing '%s' file: %s", path, err)
+		return
+	}
+
+	if !probeResult.IsMediaFile() {
+		return
+	}
+
+	mediaFile := state.MapProbeResultToMediaFile(probeResult)
+	s.mediaFiles.Add(mediaFile)
+
+	s.outLog.Printf("finished probing file %s\n", path)
 }


### PR DESCRIPTION
First quick implementation of fs watching - watching is not done
recursively at the moment, even though reading is. In order to do
this consistently, directory probing will need to be refactored in the
next commit.