### PR TITLE
Directory probing refactor

### DIFF
--- a/cmd/mpv-web-api/main.go
+++ b/cmd/mpv-web-api/main.go
@@ -103,7 +103,9 @@ func main() {
 		}
 	}
 
-	server.AddDirectories(mediaFilesDirectories)
+	go func() {
+		server.AddDirectories(mediaFilesDirectories)
+	}()
 
 	err = server.Serve()
 	if err != nil {

--- a/internal/common/directory.go
+++ b/internal/common/directory.go
@@ -6,8 +6,9 @@ import (
 )
 
 type Directory struct {
-	Path    string
-	Watched bool
+	Path      string
+	Recursive bool
+	Watched   bool
 }
 
 // EnsureDirectoryPath

--- a/internal/rest/directories.go
+++ b/internal/rest/directories.go
@@ -14,7 +14,7 @@ const (
 	watchedArg = "watched"
 )
 
-type AddDirectoriesCallback = func([]common.Directory) error
+type AddDirectoriesCallback = func([]common.Directory)
 type RemoveDirectoriesCallback = func(string) (common.Directory, error)
 
 type getDirectoriesRespone struct {
@@ -100,12 +100,14 @@ func (s *Server) directoriesPathHandler(res http.ResponseWriter, req *http.Reque
 		s.outLog.Printf("reading directory '%s' due to request from %s\n", dirPath, req.RemoteAddr)
 	}
 
-	return s.addDirectoriesCallback([]common.Directory{
+	s.addDirectoriesCallback([]common.Directory{
 		{
 			Path:    dirPath,
 			Watched: watchedDir,
 		},
 	})
+
+	return nil
 }
 
 func (s *Server) postDirectoriesFormArgumentsHandlers() map[string]common.FormArgument {

--- a/pkg/api/fs_watch.go
+++ b/pkg/api/fs_watch.go
@@ -11,9 +11,12 @@ func (s *Server) handleFsEvent(event fsnotify.Event) error {
 	}
 
 	if shouldProbeMediaPath(event.Op) {
-		go s.probeFile(event.Name) // TODO: this does not necesarilly be run as a goroutine, change in the next commit with rest of probing refactor
+		mediaFile, err := s.probeFile(event.Name)
+		if err != nil {
+			return err
+		}
 
-		return nil
+		s.mediaFiles.Add(mediaFile)
 	}
 
 	return nil


### PR DESCRIPTION
Removed unnecessary go routines, simplifying the code in question.
As a result calling code (REST handlers etc.) should ensure that adding and
probing of the directories and files is done in necessary fashion.
(REST handlers are already run in a different go routine, so no additional
creation of go routines is necessary - only main calling "AddDirectories"
needs to ensure that it's done concurrently)