### PR TITLE
Added possibility to play the playlist using its UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ It's main use is to be a backend for [mpv-web-front](https://github.com/sarpt/mp
 - `allow-cors` - bool - (default: `false`) whether Cross Origin Requests should be allowed
 - `addr` - string - (default: `localhost:3001`) address used to host the server
 - `dir` - []string - directories that should be scanned for media files only once. To specify more than one directory to be handled, multiple `--dir=<path>` arguments can be specified eg. `--dir=/path1 --dir=/path2`. The server will only handle paths provided by clients that start with one of the paths provided to `dir`.
+- `dir-recursive` - []string - recurisve variant of `dir` argument - all directories from the provider path downards are handled
 - `mpv-socket-path` - string - (default: `/tmp/mpvsocket`) path to socket file used by MPV instance
 - `playlist-prefix` - []string - list of prefixes for playlist JSON files located in directories being handled by the server instance. For more informations on playlists please check related section.
 - `socket-timeout` - int - (defualt: `15`) maximum allowed time in seconds for retrying connection to MPV socket
 - `start-mpv-instance` - bool - (default: `true`) when set to true, `mpv-web-api` will create it's own MPV process. When set to false, `mpv-web-api` will only try to connect to MPV using file at `mpv-socket-path`. Particularly useful when trying to run `mpv-web-api` in docker and connecting to local MPV instance
 - `watch-dir` - []string - directories that should be scanned for media files AND being watched for future changes to the underlying files. The argument works in the same way as a read-only variant `--dir`. If no paths are provided with neither `--dir` nor `--watch-dir`, a current working directory is watched by default.
+- `wathc-dir-recursive` - []string - recurisve variant of `watch-dir` argument - all directories from the provider path downards are handled
 
 ### Building & Execution
 
@@ -60,6 +62,7 @@ Many REST endpoints are not implemented yet, since `mpv-web-front` mostly uses S
   - `stop` - bool (default: `false`) - stops mpv playback, clearing the playback state and instructing mpv instance to go into idle.
   - `subtitleID` - string - selects subtitle stream with the provided id. Although a string, mpv indexes its subtitle streams, so it will have numerical form.
 - `GET "/playback"` - returns the state of mpv current playback.
+- `GET "/playlists"` - returns playlists handled by the api server.
 - `GET "/sse/channels"` - registers client to the SSE channels, estabilishing long running connection.
   - `channel` - string[] - names of channels client wishes to be subscribed to. In URI it takes the form of `/sse/register?channel=name1&channel=name2&channel... etc`.
   - `replay` - bool (default: `false`) - when set to `true`, the first emitted event will be of `replay` type. More info on types of SSE events in a related section below.

--- a/internal/rest/directories.go
+++ b/internal/rest/directories.go
@@ -16,6 +16,7 @@ const (
 )
 
 type AddDirectoriesCallback = func([]state.Directory)
+type LoadPlaylistCallback = func(string, bool) error
 type RemoveDirectoriesCallback = func(string) (state.Directory, error)
 
 type getDirectoriesRespone struct {

--- a/internal/rest/server.go
+++ b/internal/rest/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	removeDirectoriesCallback RemoveDirectoriesCallback
 	directories               *state.Directories
 	errLog                    *log.Logger
+	loadPlaylistCallback      LoadPlaylistCallback
 	mediaFiles                *state.MediaFiles
 	mpvManager                *mpv.Manager
 	playback                  *state.Playback

--- a/pkg/api/directories.go
+++ b/pkg/api/directories.go
@@ -94,7 +94,7 @@ func (s *Server) AddRootDirectories(rootDirectories []state.Directory) {
 				return nil
 			}
 
-			if rootDir.Path != path && !rootDir.Recursive {
+			if rootPath != path && !rootDir.Recursive {
 				return fs.SkipDir
 			}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -129,6 +129,7 @@ func NewServer(cfg Config) (*Server, error) {
 
 	restServer.SetAddDirectoriesCallback(server.AddRootDirectories)
 	restServer.SetDeleteDirectoriesCallback(server.TakeDirectory)
+	restServer.SetLoadPlaylistCallback(server.LoadPlaylist)
 	err = server.initWatchers()
 	if err != nil {
 		return server, errors.New("could not start watching for properties")

--- a/pkg/mpv/input_commands.go
+++ b/pkg/mpv/input_commands.go
@@ -3,6 +3,7 @@ package mpv
 const (
 	getVersion             = "get_version"
 	loadfileCommand        = "loadfile"
+	loadlistCommand        = "loadlist"
 	observePropertyCommand = "observe_property_string"
 	playlistNextCommand    = "playlist-next"
 	playlistPrevCommand    = "playlist-prev"

--- a/pkg/mpv/manager.go
+++ b/pkg/mpv/manager.go
@@ -121,6 +121,25 @@ func (m Manager) LoadFile(filePath string, append bool) error {
 	return err
 }
 
+// LoadList instructs mpv to start playing the playliust from provided file.
+// Second argument (append) controls whether playlist should be appended to the current playlist (instead of playlist replacement).
+func (m Manager) LoadList(filePath string, append bool) error {
+	var loadlistArg string
+	if append {
+		loadlistArg = AppendValue
+	} else {
+		loadlistArg = ReplaceValue
+	}
+
+	cmd := command{
+		name:     loadlistCommand,
+		elements: []interface{}{filePath, loadlistArg},
+	}
+	_, err := m.cd.Request(cmd)
+
+	return err
+}
+
 // LoopFile instructs mpv to change the loop state.
 func (m Manager) LoopFile(looped bool) error {
 	var loopedVal string = NoValue

--- a/pkg/state/playlist.go
+++ b/pkg/state/playlist.go
@@ -44,6 +44,16 @@ func NewPlaylist(cfg PlaylistConfig) *Playlist {
 	}
 }
 
+// All returns a copy of all PlaylistEntries being served by the instance of the server.
+func (p *Playlist) All() []PlaylistEntry {
+	entries := []PlaylistEntry{}
+
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return append(entries, p.entries...)
+}
+
 func (p *Playlist) DirectoryContentsAsEntries() bool {
 	return p.directoryContentsAsEntries
 }


### PR DESCRIPTION
- Added feature to load playlist into mpv by providing it's UUID to /rest/playback with POST
- Fixed a bug where providing either dir or watch-dir did not work if the path did not end with a / symbol