### PR TITLE
Better handling of playlist updates + handling of playlist index

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -26,6 +26,7 @@ type observePropertyHandler = func(res mpv.ObservePropertyResponse) error
 // Server is used to serve API and hold state accessible to the API.
 type Server struct {
 	address               string
+	defaultPlaylistUUID   string
 	directories           *state.Directories
 	errLog                *log.Logger
 	fsWatcher             *fsnotify.Watcher
@@ -111,6 +112,7 @@ func NewServer(cfg Config) (*Server, error) {
 
 	server := &Server{
 		cfg.Address,
+		"",
 		directories,
 		log.New(cfg.ErrWriter, logPrefix, log.LstdFlags),
 		watcher,
@@ -139,6 +141,8 @@ func NewServer(cfg Config) (*Server, error) {
 	if err != nil {
 		return server, err
 	}
+
+	server.defaultPlaylistUUID = defaultPlaylistUUID
 	server.playback.SelectPlaylist(defaultPlaylistUUID)
 
 	return server, nil
@@ -220,7 +224,7 @@ func (s Server) watchObservePropertyResponses(handlers map[string]observePropert
 
 		err := observeHandler(observePropertyResponse)
 		if err != nil {
-			s.errLog.Printf("could not handle property '%s' observer handling: %s\n", observePropertyResponse.Property, err)
+			s.errLog.Printf("error during '%s' property observer handling: %s\n", observePropertyResponse.Property, err)
 		}
 	}
 }


### PR DESCRIPTION
Before the change, every update from mpv about playlist, which fired with every entry change, was being propagated through channels even though no "interesting" changes to the playlist occured in form a changed list of entries. After the change, entries are compared before emitting on changes.

The change also improves handling of a playlist appends and improves protection of a playlist from unexpected changes (e.g. changes to playlist coming from mpv but not triggered by the server iteslef) - when list of entries for a saved, named playlist does not match the list of entries emitted from mpv, the server will switch to an unnamed playlist with the list of entries provided by mpv. This is a necessary mechanism before saving mechanism of a playlist is implemented - entries of a playlist read from disk should be only modifiable on demand from a client.

Note: currently a playlist appended through a playback is treated as a change that forces playlist switch from a named playlist to an unnamed one, even though it's a change coming from a client. Probably this should be changed in the future for easier appending to playlist (instead of POSTing to playlists endpoint) - to be considered when basic editing of playlists is implemented.