### PR TITLE
Saving of playlist current entry idx on playlist change

### DIFF
--- a/cmd/mpv-web-api/main.go
+++ b/cmd/mpv-web-api/main.go
@@ -90,7 +90,8 @@ func main() {
 	}
 
 	var mediaFilesDirectories []state.Directory
-	if len(dir.Values()) == 0 && len(watchDir.Values()) == 0 {
+	watchWorkingDir := len(dir.Values()) == 0 && len(watchDir.Values()) == 0 && len(dirRecursive.Values()) == 0 && len(watchDirRecursive.Values()) == 0
+	if watchWorkingDir {
 		wd, err := os.Getwd()
 		if err != nil {
 			errLog.Printf("could not start API server due to error while getting working directory: %s\n", err)

--- a/internal/sse/channel_handling.go
+++ b/internal/sse/channel_handling.go
@@ -41,14 +41,6 @@ type ObserversChange struct {
 
 type getSseHandler = func(res http.ResponseWriter, req *http.Request)
 
-// channel is used to construct channel on which subscribers can listen to on a mutexed on a single SSE keep-alive connection
-// type channel struct {
-// 	observers     observers
-// 	variant       state.SSEChannelVariant
-// 	changeHandler sseChangeHandler
-// 	replayHandler sseReplayHandler
-// }
-
 // handlerConfig is used to control creation of SSE handler for Server
 type handlerConfig struct {
 	Channels map[state.SSEChannelVariant]channel

--- a/internal/sse/playlists.go
+++ b/internal/sse/playlists.go
@@ -9,6 +9,8 @@ import (
 
 const (
 	playlistsSSEChannelVariant state.SSEChannelVariant = "playlists"
+
+	playlistsReplay state.PlaylistsChangeVariant = "replay"
 )
 
 type playlistsChannel struct {
@@ -50,7 +52,7 @@ func (pc *playlistsChannel) RemoveObserver(address string) {
 }
 
 func (pc *playlistsChannel) Replay(res ResponseWriter) error {
-	return res.SendChange(pc.playlists, pc.Variant(), playbackReplaySseEvent)
+	return res.SendChange(pc.playlists, pc.Variant(), string(playlistsReplay))
 }
 
 func (pc *playlistsChannel) ServeObserver(address string, res ResponseWriter, done chan<- bool, errs chan<- error) {
@@ -85,7 +87,7 @@ func (pc *playlistsChannel) changeHandler(res ResponseWriter, change state.Playl
 		return res.SendEmptyChange(pc.Variant(), string(change.Variant))
 	}
 
-	return res.SendChange(pc.playlists, pc.Variant(), string(change.Variant))
+	return res.SendChange(change.Playlist, pc.Variant(), string(change.Variant))
 }
 
 func (pc *playlistsChannel) BroadcastToChannelObservers(change state.PlaylistsChange) {

--- a/internal/sse/server.go
+++ b/internal/sse/server.go
@@ -60,8 +60,8 @@ func NewServer(cfg Config) *Server {
 	}
 }
 
-// InitDispatchers starts listening on state changes channels for further distribution to its observers.
-func (s *Server) InitDispatchers() {
+// SubscribeToStateChanges starts listening on state changes channels for further distribution to its observers.
+func (s *Server) SubscribeToStateChanges() {
 	directoriesChannel := s.channels[directoriesSSEChannelVariant].(*directoriesChannel) // TODO: Ooof... Eww... Remove when rewriting with generics
 	s.directories.Subscribe(directoriesChannel.BroadcastToChannelObservers, func(err error) {})
 

--- a/internal/sse/status.go
+++ b/internal/sse/status.go
@@ -9,6 +9,9 @@ import (
 
 const (
 	statusSSEChannelVariant state.SSEChannelVariant = "status"
+
+	// statusReplay notifies about replay of status state.
+	statusReplay state.StatusChangeVariant = "replay"
 )
 
 type statusChannel struct {
@@ -48,7 +51,7 @@ func (sc *statusChannel) RemoveObserver(address string) {
 }
 
 func (sc *statusChannel) Replay(res ResponseWriter) error {
-	return res.SendChange(sc.status, sc.Variant(), string(state.StatusReplay))
+	return res.SendChange(sc.status, sc.Variant(), string(statusReplay))
 }
 
 func (sc *statusChannel) ServeObserver(address string, res ResponseWriter, done chan<- bool, errs chan<- error) {

--- a/pkg/state/playback.go
+++ b/pkg/state/playback.go
@@ -40,6 +40,9 @@ const (
 	// PlaylistSelectionChange notifies about change of currently played playlist.
 	PlaylistSelectionChange PlaybackChangeVariant = "playlistSelectionChange"
 
+	// PlaylistUnloadChange notifies about unload of playlist.
+	PlaylistUnloadChange PlaybackChangeVariant = "playlistUnloadChange"
+
 	// PlaylistCurrentIdxChange notifies about change of currently played entry in a selected playlist.
 	PlaylistCurrentIdxChange PlaybackChangeVariant = "playlistCurrentIdxChange"
 )
@@ -48,6 +51,7 @@ const (
 // TODO: implement playback change to carry information on the change (using either interfaces or generics in go2).
 type PlaybackChange struct {
 	Variant PlaybackChangeVariant
+	Value   interface{}
 }
 
 // Playback contains information about currently played media file.
@@ -115,6 +119,10 @@ func (p *Playback) MarshalJSON() ([]byte, error) {
 	return json.Marshal(pJSON)
 }
 
+func (p *Playback) PlaylistCurrentIdx() int {
+	return p.playlistCurrentIdx
+}
+
 func (p *Playback) PlaylistUUID() string {
 	return p.playlistUUID
 }
@@ -178,6 +186,11 @@ func (p *Playback) SetPause(paused bool) {
 
 // SelectPlaylist sets currently played uuid of a playlist.
 func (p *Playback) SelectPlaylist(uuid string) {
+	p.broadcaster.changes <- PlaybackChange{
+		Variant: PlaylistUnloadChange,
+		Value:   p.playlistUUID,
+	}
+
 	p.playlistUUID = uuid
 
 	p.broadcaster.changes <- PlaybackChange{

--- a/pkg/state/playlist.go
+++ b/pkg/state/playlist.go
@@ -15,6 +15,7 @@ type Playlist struct {
 	entries                    []PlaylistEntry
 	name                       string
 	lock                       *sync.RWMutex
+	path                       string
 	uuid                       string
 }
 
@@ -24,6 +25,7 @@ type playlistJSON struct {
 	DirectoryContentsAsEntries bool            `json:"DirectoryContentsAsEntries"`
 	Entries                    []PlaylistEntry `json:"Entries"`
 	Name                       string          `json:"Name"`
+	Path                       string          `json:"Path"`
 	UUID                       string          `json:"UUID"`
 }
 
@@ -33,6 +35,7 @@ type PlaylistConfig struct {
 	DirectoryContentsAsEntries bool
 	Entries                    []PlaylistEntry
 	Name                       string
+	Path                       string
 }
 
 // NewPlaylist constructs Playlist state.
@@ -44,6 +47,7 @@ func NewPlaylist(cfg PlaylistConfig) *Playlist {
 		entries:                    cfg.Entries,
 		name:                       cfg.Name,
 		lock:                       &sync.RWMutex{},
+		path:                       cfg.Path,
 		uuid:                       uuid.NewString(),
 	}
 }
@@ -92,6 +96,7 @@ func (p *Playlist) EntriesDiffer(entries []PlaylistEntry) bool {
 
 // MarshalJSON satisifes json.Marshaller.
 func (p *Playlist) MarshalJSON() ([]byte, error) {
+	p.lock.Lock()
 	pJSON := playlistJSON{
 		DirectoryContentsAsEntries: p.directoryContentsAsEntries,
 		Description:                p.description,
@@ -99,7 +104,27 @@ func (p *Playlist) MarshalJSON() ([]byte, error) {
 		Name:                       p.name,
 		UUID:                       p.uuid,
 	}
+	p.lock.Unlock()
+
 	return json.Marshal(pJSON)
+}
+
+func (p *Playlist) Description() string {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return p.description
+}
+
+func (p *Playlist) Name() string {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return p.name
+}
+
+func (p *Playlist) Path() string {
+	return p.path
 }
 
 func (p *Playlist) setCurrentEntryIdx(idx int) {

--- a/pkg/state/status.go
+++ b/pkg/state/status.go
@@ -14,9 +14,6 @@ type StatusChangeVariant string
 type SSEChannelVariant string
 
 const (
-	// StatusReplay notifies about replay of status state.
-	StatusReplay StatusChangeVariant = "replay"
-
 	// ClientObserverAdded notifies about addition of new client observer.
 	ClientObserverAdded StatusChangeVariant = "client-observer-added"
 


### PR DESCRIPTION
Due to implementation of a subscriber pattern in mpv states, it's now possible for server to observe on the state changes just as a sse server would. This enables watching on various playlist-related changes on a state to be separated from particular state-related event handlers (I don't want playlist-related logic to run in a handler of mpv property change, because changes to the playlist will also happen from the REST/other APIs requests). As such a stub of functionality is implemented with this commit - changes to the current named (read from file) playlist are saved on a change of playlists playback. The next step would be to also save currently played playlist state on common signals.