### PR TITLE
Implement server plugin mechanism

### DIFF
--- a/internal/rest/directories.go
+++ b/internal/rest/directories.go
@@ -23,14 +23,6 @@ type getDirectoriesRespone struct {
 	Directories map[string]state.Directory `json:"directories"`
 }
 
-func (s *Server) SetAddDirectoriesCallback(callback AddDirectoriesCallback) {
-	s.addDirectoriesCallback = callback
-}
-
-func (s *Server) SetDeleteDirectoriesCallback(callback RemoveDirectoriesCallback) {
-	s.removeDirectoriesCallback = callback
-}
-
 func (s *Server) getDirectoriesHandler(res http.ResponseWriter, req *http.Request) {
 	directoriesResponse := getDirectoriesRespone{
 		Directories: s.directories.All(),

--- a/internal/rest/playback.go
+++ b/internal/rest/playback.go
@@ -22,10 +22,6 @@ const (
 	subtitleIDArg   = "subtitleID"
 )
 
-func (s *Server) SetLoadPlaylistCallback(cb LoadPlaylistCallback) {
-	s.loadPlaylistCallback = cb
-}
-
 func (s *Server) getPlaybackHandler(res http.ResponseWriter, req *http.Request) {
 	json, err := json.Marshal(s.playback)
 	if err != nil {

--- a/internal/sse/server.go
+++ b/internal/sse/server.go
@@ -1,17 +1,24 @@
 package sse
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 
+	"github.com/sarpt/mpv-web-api/pkg/api"
 	"github.com/sarpt/mpv-web-api/pkg/state"
 )
 
 const (
 	logPrefix = "sse.Server#"
 
-	registerPath = "/sse/channels"
+	name     = "SSE Server"
+	pathBase = "sse"
+)
+
+var (
+	registerPath = fmt.Sprintf("/%s/channels", pathBase)
 )
 
 // Server holds information about handled SSE connections and their observers.
@@ -29,38 +36,61 @@ type Server struct {
 
 // Config controls behaviour of the SSE server.
 type Config struct {
-	Directories *state.Directories
-	ErrWriter   io.Writer
-	MediaFiles  *state.MediaFiles
-	OutWriter   io.Writer
-	Playback    *state.Playback
-	Playlists   *state.Playlists
-	Status      *state.Status
+	ErrWriter io.Writer
+	OutWriter io.Writer
 }
 
 // NewServer prepares and returns SSE server to handle SSE connections and observers.
 func NewServer(cfg Config) *Server {
 	return &Server{
-		channels: map[state.SSEChannelVariant]channel{
-			directoriesSSEChannelVariant: newDirectoriesChannel(cfg.Directories),
-			mediaFilesSSEChannelVariant:  newMediaFilesChannel(cfg.MediaFiles),
-			playbackSSEChannelVariant:    newPlaybackChannel(cfg.Playback),
-			playlistsSSEChannelVariant:   newPlaylistsChannel(cfg.Playback, cfg.Playlists),
-			statusSSEChannelVariant:      newStatusChannel(cfg.Status),
-		},
-		directories:      cfg.Directories,
+		channels:         map[state.SSEChannelVariant]channel{},
 		errLog:           log.New(cfg.ErrWriter, logPrefix, log.LstdFlags),
-		mediaFiles:       cfg.MediaFiles,
 		observersChanges: make(chan ObserversChange),
 		outLog:           log.New(cfg.OutWriter, logPrefix, log.LstdFlags),
-		playback:         cfg.Playback,
-		playlists:        cfg.Playlists,
-		status:           cfg.Status,
 	}
 }
 
-// SubscribeToStateChanges starts listening on state changes channels for further distribution to its observers.
-func (s *Server) SubscribeToStateChanges() {
+// Handler returns map of HTTPs methods and their handlers.
+func (s *Server) Handler() http.Handler {
+	sseCfg := handlerConfig{
+		Channels: s.channels,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(registerPath, s.createSseRegisterHandler(sseCfg))
+
+	return mux
+}
+
+func (s *Server) Init(apiServer *api.Server) error {
+	s.directories = apiServer.Directories()
+	s.mediaFiles = apiServer.MediaFiles()
+	s.playback = apiServer.Playback()
+	s.playlists = apiServer.Playlists()
+	s.status = apiServer.Status()
+
+	s.channels[directoriesSSEChannelVariant] = newDirectoriesChannel(s.directories)
+	s.channels[mediaFilesSSEChannelVariant] = newMediaFilesChannel(s.mediaFiles)
+	s.channels[playbackSSEChannelVariant] = newPlaybackChannel(s.playback)
+	s.channels[playlistsSSEChannelVariant] = newPlaylistsChannel(s.playback, s.playlists)
+	s.channels[statusSSEChannelVariant] = newStatusChannel(s.status)
+
+	go s.watchSSEObserversChanges()
+	s.subscribeToStateChanges()
+
+	return nil
+}
+
+func (s *Server) Name() string {
+	return name
+}
+
+func (s *Server) PathBase() string {
+	return pathBase
+}
+
+// subscribeToStateChanges starts listening on state changes channels for further distribution to its observers.
+func (s *Server) subscribeToStateChanges() {
 	directoriesChannel := s.channels[directoriesSSEChannelVariant].(*directoriesChannel) // TODO: Ooof... Eww... Remove when rewriting with generics
 	s.directories.Subscribe(directoriesChannel.BroadcastToChannelObservers, func(err error) {})
 
@@ -77,19 +107,7 @@ func (s *Server) SubscribeToStateChanges() {
 	s.status.Subscribe(statusChannel.BroadcastToChannelObservers, func(err error) {})
 }
 
-// Handler returns map of HTTPs methods and their handlers.
-func (s *Server) Handler() http.Handler {
-	sseCfg := handlerConfig{
-		Channels: s.channels,
-	}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc(registerPath, s.createSseRegisterHandler(sseCfg))
-
-	return mux
-}
-
-func (s Server) WatchSSEObserversChanges() {
+func (s Server) watchSSEObserversChanges() {
 	for {
 		change, open := <-s.observersChanges
 		if !open {

--- a/pkg/api/routing.go
+++ b/pkg/api/routing.go
@@ -1,21 +1,15 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 )
 
-const (
-	ssePath  = "/sse/"
-	restPath = "/rest/"
-)
-
 func (s *Server) mainHandler() *http.ServeMux {
-	sseHandlers := s.sseServer.Handler()
-	restHandler := s.restServer.Handler()
-
 	mux := http.NewServeMux()
-	mux.Handle(ssePath, sseHandlers)
-	mux.Handle(restPath, restHandler)
+	for _, server := range s.pluginServers {
+		mux.Handle(fmt.Sprintf("/%s/", server.PathBase()), server.Handler())
+	}
 
 	return mux
 }


### PR DESCRIPTION
To enable more api styles in the future in addition to REST and SSE (like graphql or something other), a simple type of 'PluginServer' interface is used by api.Server. This changes responsibility of setting up current REST and SSE servers to themselves by taking in init method an exposed api.Server (it should be a separate interface exposing only necessary methods - tbd) and setting up themselves before being served, instead of an earlies poc mechanism of server being the one to set them up.